### PR TITLE
fixed method calls with files

### DIFF
--- a/libsimba/simba_contract.py
+++ b/libsimba/simba_contract.py
@@ -65,7 +65,7 @@ class SimbaContract:
         :rtype: json
         """
         query_args = query_args or {}
-        return SimbaRequest("v2/apps/{}/{}/".format(self.contract_uri, method_name), query_args, method='POST').send(json_payload=json.dumps(inputs), files=files)
+        return SimbaRequest("v2/apps/{}/{}/".format(self.contract_uri, method_name), query_args, method='POST').send(json_payload=inputs, files=files)
 
     @filter_set
     def get_transactions(self, query_args: Optional[dict] = None):

--- a/libsimba/simba_request.py
+++ b/libsimba/simba_request.py
@@ -38,11 +38,12 @@ class SimbaRequest:
             response = httpx.get(self.url, headers=headers, follow_redirects=True)
             return self._process_response(response, headers, fetch_all)
         elif self.method == 'post':
-            headers.update({'content-type': 'application/json'})
             json_payload = json_payload or {}
             if files is not None:
-                response = httpx.post(self.url, headers=headers, data=json.dumps(json_payload), files=files, follow_redirects=True)
+                string_keys_and_vals = {str(key): str(val) for key, val in json_payload.items()}
+                response = httpx.post(self.url, headers=headers, data=string_keys_and_vals, files=files, follow_redirects=True)
             else:
+                headers.update({'content-type': 'application/json'})
                 response = httpx.post(self.url, headers=headers, data=json.dumps(json_payload), follow_redirects=True)
             return self._process_response(response, headers)
 
@@ -53,11 +54,12 @@ class SimbaRequest:
                 response = await async_client.get(self.url, headers=headers, follow_redirects=True)
                 return await self._process_response_async(async_client, response, headers, fetch_all)
             elif self.method == 'post':
-                headers.update({'content-type': 'application/json'})
                 json_payload = json_payload or {}
                 if files is not None:
-                    response = await async_client.post(self.url, headers=headers, data=json_payload, follow_redirects=True, files=files)
+                    string_keys_and_vals = {str(key): str(val) for key, val in json_payload.items()}
+                    response = await async_client.post(self.url, headers=headers, data=string_keys_and_vals, follow_redirects=True, files=files)
                 else:
+                    headers.update({'content-type': 'application/json'})
                     response = await async_client.post(self.url, headers=headers, data=json_payload, follow_redirects=True)
                 return await self._process_response_async(async_client, response, headers)
 


### PR DESCRIPTION
We were unable to submit multipart-form data, for a few main reasons:
1) in SimbaContract.call_contract_method_with_files, we were automatically converting json_payload to json.dumps(json_payload), converting our inputs to string
2) in SimbaRequest.send(), we were calling headers.update({'content-type': 'application/json'}) for all posts, even those including files, which prevents httpx from creating boundary headers for multipart/form-data requests
3) as 1) references, we actually need to be passing inputs as {"str_key": "str_val"}, rather than '{str_key: str_val}'. adding string_keys_and_vals = {str(key): str(val) for key, val in json_payload.items()} fixes this